### PR TITLE
Bump enum-iterator version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ readme = "README.md"
 # build = "./generate.rs"
 
 [dependencies]
-enum-iterator = "0.8.1"
+enum-iterator = "1.4.1"
 

--- a/generate.rs
+++ b/generate.rs
@@ -10,7 +10,7 @@ extern crate enum_iterator;
 
 /// Icon containing all possible icon names as enum discriminants
 #[repr(C)]
-#[derive(Debug, Copy, Clone, IntoEnumIterator, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Sequence)]
 pub enum Icon {\n";
 const RUST_CODE_END_1: &str = "}\n\n";
 const RUST_CODE_START_2: &str = "

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ extern crate enum_iterator;
 
 /// Icon containing all possible icon names as enum discriminants
 #[repr(C)]
-#[derive(Debug, Copy, Clone, IntoEnumIterator, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Sequence)]
 pub enum Icon {
     TenK,
     TenMp,


### PR DESCRIPTION
Not strictly required, but avoids multiple versions in projects using the latest.